### PR TITLE
[Fix]サークル詳細画面のモーダルのプレビューのバグ修正

### DIFF
--- a/app/views/public/circles/_circle_edit.html.erb
+++ b/app/views/public/circles/_circle_edit.html.erb
@@ -22,7 +22,9 @@
           <p class="m-0 text-blue font-weight-bold">活動場所</p>
         </div>
         <div class="col profile-center">
-          <p class="m-0 text-blue"><%= circle.prefecture.prefecture_name %>/<%= @circle.city.city_name %></p>
+          <p class="m-0 text-blue">
+            <%= circle.prefecture.prefecture_name %>/
+          <%= @circle.city.city_name %></p>
         </div>
       </div>
       <div class="row my-3 user-introduction bg-light">
@@ -58,10 +60,14 @@
 </div>
 
 <div class="d-none" id="edit-form">
-  <%= render "public/circles/form", circle: circle, route: circle_path(circle), prefectures: prefectures, submit_text: "変更を保存", async: false %>
-  <div class="row ml-1">
-    <div class="col-3">
-    </div>
+  <%= render "public/circles/form", circle:       circle,
+                                    route:        circle_path(circle),
+                                    prefectures:  prefectures,
+                                    submit_text:  "変更を保存",
+                                    async:        false,
+                                    input_id:     "image_input",
+                                    prev_id:      "img_prev" %>
+  <div class="row">
     <div class="col-auto mx-auto text-center">
       <button type="button" class="btn-custom-red cancel-edit">編集画面を閉じる</button>
     </div>

--- a/app/views/public/circles/_form.html.erb
+++ b/app/views/public/circles/_form.html.erb
@@ -11,11 +11,11 @@
           <div class="col-md-3 col-sm-12 text-center my-auto">
             <%= f.label :circle_image, "アイコン", class: "font-weight-bold text-blue" %>
           </div>
-          <div class="col-5 text-blue mx-auto">
-            <%= f.label :circle_image, class: "image-label circle", for: "circle_image_input" do %>
-              <%= image_tag (circle.circle_image.attached? ? circle.circle_image : "no_image.png"), id: "circle_img_prev", class: "image-fluid" %>
+          <div class="col-md-3 col-5 text-blue mx-auto">
+            <%= f.label :circle_image, class: "image-label circle", for: input_id do %>
+              <%= image_tag (circle.circle_image.attached? ? circle.circle_image : "no_image.png"), id: prev_id, class: "image-fluid" %>
             <% end %>
-            <%= f.file_field :circle_image, accept: "image/*", id: "circle_image_input", class: "image_select circle_icon_select" %>
+            <%= f.file_field :circle_image, accept: "image/*", id: input_id, class: "image_select circle_icon_select" %>
           </div>
         </div>
         <div class="row my-3 user-introduction">

--- a/app/views/public/circles/create.js.erb
+++ b/app/views/public/circles/create.js.erb
@@ -1,2 +1,8 @@
-$('#modalCircleFormContent').html('<%= j render "form", circle: @circle, route: circles_path, prefectures: @prefectures, submit_text: "作成", async: false  %>');
+$('#modalCircleFormContent').html('<%= j render "form", circle:       @circle,
+                                                        route:        circles_path,
+                                                        prefectures:  @prefectures,
+                                                        submit_text:  "作成",
+                                                        async:        false,
+                                                        input_id:     "circle_image_input",
+                                                        prev_id:      "circle_img_prev" %>');
 $('#CircleModal').modal('show');

--- a/app/views/public/circles/new.js.erb
+++ b/app/views/public/circles/new.js.erb
@@ -1,2 +1,7 @@
-$('#modalCircleFormContent').html('<%= j render "form", circle: @circle, route: circles_path, prefectures: @prefectures, submit_text: "作成", async: false  %>');
+$('#modalCircleFormContent').html('<%= j render "form", circle:       @circle,
+                                                        route:        circles_path,
+                                                        prefectures:  @prefectures,
+                                                        submit_text:  "作成", async: false,
+                                                        input_id:     "circle_image_input",
+                                                        prev_id:      "circle_img_prev" %>');
 $('#CircleModal').modal('show');

--- a/app/views/public/circles/show.html.erb
+++ b/app/views/public/circles/show.html.erb
@@ -12,7 +12,7 @@
           <%= link_to "削除", circle_path(@circle), method: :delete, data: { confirm: "本当に消しますか?" }, class: "btn-custom-red" %>
         </div>
       <% else %>
-        <div class="col-md-auto col-sm-12 ">
+        <div class="col-md-auto col-sm-12 text-center mb-3">
           <h3 class="page-title my-auto">サークル詳細</h3>
         </div>
         <div class="col-auto my-auto">

--- a/app/views/public/posts/_form.html.erb
+++ b/app/views/public/posts/_form.html.erb
@@ -11,10 +11,10 @@
         <div class="row text-center">
           <div class="col-md-3 col-sm-12 my-auto"><%= f.label :post_image, "投稿画像", class: "font-weight-bold text-blue" %></div>
           <div class="col-5 my-auto mx-auto">
-            <%= f.label :post_image, class: "image-label square", for: "post_image_input" do %>
-              <%= image_tag (post.post_image.attached? ? post.post_image : "no_image.png"), id: "post_img_prev", class: "image-fluid" %>
+            <%= f.label :post_image, class: "image-label square", for: input_id do %>
+              <%= image_tag (post.post_image.attached? ? post.post_image : "no_image.png"), id: prev_id, class: "image-fluid" %>
             <% end %>
-            <%= f.file_field :post_image, accept: "image/*", id: "post_image_input", class: "image_select" %>
+            <%= f.file_field :post_image, accept: "image/*", id: input_id, class: "image_select" %>
           </div>
         </div>
         <div class="row text-center mt-5">

--- a/app/views/public/posts/_post_display.html.erb
+++ b/app/views/public/posts/_post_display.html.erb
@@ -1,4 +1,4 @@
-<% border_class = obj.user.is_active ? "blue-border" : "gray-border" %>
+<% border_class = obj.user.is_active ? "fit-blue-border" : "gray-border" %>
 <% text_class = obj.user.is_active ? "text-blue" : "text-gray" %>
 
 <div class="row my-3">

--- a/app/views/public/posts/_post_edit.html.erb
+++ b/app/views/public/posts/_post_edit.html.erb
@@ -9,8 +9,14 @@
 <% end %>
 
 <div class="d-none" id="edit-form">
-  <%= render "public/posts/form", post: post, submit_text: "保存", route: post_path, circles: circles, async: false %>
-  <div class="row ml-1">
+  <%= render "public/posts/form", post:         post,
+                                  submit_text:  "保存",
+                                  route:        post_path,
+                                  circles:      circles,
+                                  async:        false,
+                                  input_id:     "image_input",
+                                  prev_id:      "img_prev" %>
+  <div class="row">
     <div class="col text-center">
       <button type="button" class="btn-custom-red cancel-edit">編集画面を閉じる</button>
     </div>

--- a/app/views/public/posts/create.js.erb
+++ b/app/views/public/posts/create.js.erb
@@ -1,2 +1,8 @@
-$('#modalFormContent').html('<%= j render "form", post: @post, submit_text: "投稿", route: posts_path, circles: @circles, async: true  %>');
+$('#modalFormContent').html('<%= j render "form", post: @post,
+                                                  submit_text: "投稿",
+                                                  route: posts_path,
+                                                  circles: @circles,
+                                                  async: true,
+                                                  input_id:     "post_image_input",
+                                                  prev_id:      "post_img_prev" %>');
 $('#PostModal').modal('show');

--- a/app/views/public/posts/new.js.erb
+++ b/app/views/public/posts/new.js.erb
@@ -1,2 +1,8 @@
-$('#modalFormContent').html('<%= j render "form", post: @post, submit_text: "投稿", route: posts_path, circles: @circles, async: false  %>');
+$('#modalFormContent').html('<%= j render "form", post:         @post,
+                                                  submit_text:  "投稿",
+                                                  route:        posts_path,
+                                                  circles:      @circles,
+                                                  async:        false,
+                                                  input_id:     "post_image_input",
+                                                  prev_id:      "post_img_prev" %>');
 $('#PostModal').modal('show');


### PR DESCRIPTION
サークル詳細画面のモーダルのプレビューのバグ修正。
(サークル詳細画面でサークル作成モーダルを開き、画像を選択するとプレビューされない不具合を修正。
原因はidの競合)